### PR TITLE
Some improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ just remove the `previous_signature.bin` file.
 
 ## build
 
-To build the project you need the development files for libcurl and OpenSSL.
+To build the project you need the development files for libcurl and OpenSSL (e.g. in recent debian `libcurl4-openssl-dev` and  `libssl-dev`).
 
 ```bash
 git clone https://github.com/ubirch/ubirch-client-c-example --recursive

--- a/src/api_http.c
+++ b/src/api_http.c
@@ -43,9 +43,8 @@ static size_t response_callback(void *data, size_t size, size_t nmemb, void *use
 }
 
 
-int ubirch_send(const char* url, const configuration_t* config,
-        const unsigned char *data, const size_t len, int* http_status,
-        msgpack_unpacker* unpacker) {
+int ubirch_send(const char* url, const unsigned char *data, const size_t len,
+        long* http_status, msgpack_unpacker* unpacker) {
     unsigned int ii;
     DEBUGHEXDUMP("Sending UPP:", data, len);
 
@@ -112,7 +111,7 @@ int ubirch_send(const char* url, const configuration_t* config,
     }
     curl_global_cleanup();
 
-    if (response_context.verified) {
+    if (response_context.verified || unpacker == NULL) {
         return UBIRCH_SEND_OK;
     } else {
         return UBIRCH_SEND_VERIFICATION_FAILED;

--- a/src/api_http.h
+++ b/src/api_http.h
@@ -5,15 +5,49 @@
 #include <msgpack.h>
 #include "storage.h"
 
-int ubirch_message(ubirch_protocol* upp, char* data, size_t length);
-
+/*
+ * Send data to the ubirch backend.
+ * @param url The backend url.
+ * @param data The msgpack encoded data to send.
+ * @param len The length of the data packet.
+ * @param http_status The http status of the backend response.
+ * @param unpacker The msgpack unpacker to feed the response to or NULL in case
+ *        you don't expect an answer or you are not interested in it.
+ *        Verification is only done if you provide an unpacker.
+ * @return UBIRCH_SEND_OK
+ *         UBIRCH_SEND_VERIFICATION_FAILED if unpacker is not NULL and verification failed
+ *         UBIRCH_SEND_ERROR if any error occured
+ */
 #define UBIRCH_SEND_OK (0)
 #define UBIRCH_SEND_VERIFICATION_FAILED (1)
 #define UBIRCH_SEND_ERROR (2)
-int ubirch_send(const char* url, const configuration_t* config, const unsigned char *data,
-        const size_t len, int* http_status, msgpack_unpacker* unpacker);
+int ubirch_send(const char* url, const unsigned char *data, const size_t len,
+        long* http_status, msgpack_unpacker* unpacker);
 
+/*
+ * Callback type for ubirch_parse_backend_response. To be called on binary data.
+ *
+ * @param data A pointer to the data.
+ * @param len Size of data.
+ */
 typedef void (*ubirch_response_bin_data_handler)(const void* data, const size_t len);
+
+/*
+ * Parse a msgpack response that contains a ubirch-protocol message.
+ * The function expects
+ *      1. proto_chained type
+ *      2. matching previous signature with signature of previous UPP
+ *      3. payload of binary type UBIRCH_PROTOCOL_TYPE_BIN
+ * otherwise it will not call the handler on this binary data.
+ *
+ * @param unpacker The unpacker holding unparsed data.
+ * @param previous_upp A reference to the previous UPP.
+ * @param handler A handler for the received payload.
+ * @return UBIRCH_PARSE_BACKEND_RESPONSE_OK
+ *         UBIRCH_PARSE_BACKEND_RESPONSE_ERROR if any error occured
+ */
+#define UBIRCH_PARSE_BACKEND_RESPONSE_OK (0)
+#define UBIRCH_PARSE_BACKEND_RESPONSE_ERROR (-1)
 int ubirch_parse_backend_response(msgpack_unpacker *unpacker, ubirch_protocol* previous_upp,
         ubirch_response_bin_data_handler handler);
 

--- a/src/storage.c
+++ b/src/storage.c
@@ -243,9 +243,6 @@ void print_config(void) {
     // convert configuration values into readable data
     printf("== configuration ==\n");
     print_config_uuid();
-    print_config_value_base64("private key", configuration.private_key,
-            configuration.private_key_bit,
-            UBIRCH_CLIENT_CONFIG_PRIVATE_KEY_LENGTH);
     print_config_value_base64("public key", configuration.public_key,
             configuration.public_key_bit,
             UBIRCH_CLIENT_CONFIG_PUBLIC_KEY_LENGTH);

--- a/src/storage.c
+++ b/src/storage.c
@@ -253,7 +253,7 @@ void print_config(void) {
 }
 
 void print_previous_signature(void) {
-    printf("== last successfully anchored signature ==\n");
+    printf("== signature of last successfully anchored hash ==\n");
     unsigned char buffer[UBIRCH_PROTOCOL_SIGN_SIZE];
     if (read_data_from_file(UBIRCH_CLIENT_PREVIOUS_SIGNATURE_FILE, buffer,
                 UBIRCH_PROTOCOL_SIGN_SIZE) == 0) {

--- a/src/storage.c
+++ b/src/storage.c
@@ -242,14 +242,18 @@ static void print_config_value_base64(const char* name, unsigned char* buffer,
 void print_config(void) {
     // convert configuration values into readable data
     printf("== configuration ==\n");
-    print_config_uuid();
-    print_config_value_base64("public key", configuration.public_key,
-            configuration.public_key_bit,
-            UBIRCH_CLIENT_CONFIG_PUBLIC_KEY_LENGTH);
-    print_config_value_base64("server key", configuration.server_key,
-            configuration.server_key_bit,
-            UBIRCH_CLIENT_CONFIG_SERVER_KEY_LENGTH);
-    print_config_authtoken();
+    if (load_config() == 0) {
+        print_config_uuid();
+        print_config_value_base64("public key", configuration.public_key,
+                configuration.public_key_bit,
+                UBIRCH_CLIENT_CONFIG_PUBLIC_KEY_LENGTH);
+        print_config_value_base64("server key", configuration.server_key,
+                configuration.server_key_bit,
+                UBIRCH_CLIENT_CONFIG_SERVER_KEY_LENGTH);
+        print_config_authtoken();
+    } else {
+        printf("No config file present.\n");
+    }
 }
 
 void print_previous_signature(void) {

--- a/src/ubirch-client.c
+++ b/src/ubirch-client.c
@@ -222,10 +222,9 @@ int main(int argc, char* argv[]) {
 
 
         /* send data to backend */
-        int http_status = -1;
+        long http_status = -1;
         int return_value = -1;
-        switch (ubirch_send(url, config, upp->data, upp->size, &http_status,
-                    unpacker)) {
+        switch (ubirch_send(url, upp->data, upp->size, &http_status, unpacker)) {
             case UBIRCH_SEND_OK:
                 switch (http_status) {
                     case 200:
@@ -248,7 +247,7 @@ int main(int argc, char* argv[]) {
                         }
                         break;
                     default:
-                        printf("https status: %d, something went wrong...\n",
+                        printf("https status: %ld, something went wrong...\n",
                                 http_status);
                         break;
                 }

--- a/src/ubirch-client.c
+++ b/src/ubirch-client.c
@@ -114,6 +114,16 @@ int main(int argc, char* argv[]) {
         }
         printf("OK\n");
         exit(0);
+    } else if (argc == 2 && strcmp(argv[1], "info") == 0) {
+        /* print out some usefull information */
+        printf("== ubirch-client ==\n");
+        printf("backend data url: %s\n", CONFIG_UBIRCH_BACKEND_DATA_URL);
+        printf("backend key server url: %s\n\n", CONFIG_UBIRCH_BACKEND_KEY_SERVER_URL);
+        print_config();
+        printf("\n");
+        print_previous_signature();
+        printf("\n");
+        exit(0);
     }
 
     /* load configuration from file
@@ -124,17 +134,7 @@ int main(int argc, char* argv[]) {
         exit(-1);
     }
 
-    if (argc == 2 && strcmp(argv[1], "info") == 0) {
-        /* print out some usefull information */
-        printf("== ubirch-client ==\n");
-        printf("backend data url: %s\n", CONFIG_UBIRCH_BACKEND_DATA_URL);
-        printf("backend key server url: %s\n\n", CONFIG_UBIRCH_BACKEND_KEY_SERVER_URL);
-        print_config();
-        printf("\n");
-        print_previous_signature();
-        printf("\n");
-        exit(0);
-    } else if ((argc == 3 && strcmp(argv[1], "send") == 0)
+    if ((argc == 3 && strcmp(argv[1], "send") == 0)
             || (argc == 2 && strcmp(argv[1], "register") == 0)) {
         /* register your keys or send hash of given file path */
 

--- a/src/ubirch-client.c
+++ b/src/ubirch-client.c
@@ -103,6 +103,7 @@ int main(int argc, char* argv[]) {
         exit(0);
     } else if (argc == 2 && strcmp(argv[1], "generatekeys") == 0) {
         /* generate new keypair and write it to config file */
+        load_config();
         configuration_t* config = get_config();
         crypto_sign_keypair(config->public_key, config->private_key);
         config->public_key_bit = 1;


### PR DESCRIPTION
This PR includes:
1. `generatekeys` subcommand loads the config file before generating the keys and storing the config back into the file. Before it overwrote the existing config file.
2. Private key is not printed with `info` subcommand any more.
3. Fix formulation in `info` subcommand.
4. The `ubirch_send` function had some minor issues, compare [commit](https://github.com/ubirch/ubirch-client-c-example/commit/164e611eed1862bf1e78152a9d1a963abe9601cb) message.
5. `info` subcommand works now even if there is no config file.
6. Debian package names are added to README.md.